### PR TITLE
add include_template method

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,29 @@ Outputs may be defined using the `output` function:
 output :OutputName, Fn::ref(:ResourceName)
 ```
 
+#### Including code from multiple files
+
+Templates can get pretty large, and splitting template code into multiple
+files can help keep things more manageable. The `include_template`
+function works in a similar way to ruby's `require_relative`, but
+within the context of the CloudFormation stack:
+
+```ruby
+include_template 'ec2.rb'
+```
+
+You can also include multiple files in a single call:
+
+```ruby
+include_template(
+  'stack/ec2.rb',
+  'stack/elb.rb'
+)
+```
+
+The path to included files is relative to the base template file
+(e.g. the `converge` command `-t` option).
+
 ## SDK
 
 Embedding the Cfer SDK involves interacting with two components: The `Client` and the `Stack`.

--- a/lib/cfer/core/stack.rb
+++ b/lib/cfer/core/stack.rb
@@ -159,6 +159,17 @@ module Cfer::Core
       to_h.to_json
     end
 
+    # Includes template code from one or more files, and evals it in the context of this stack.
+    # Filenames are relative to the file containing the invocation of this method.
+    def include_template(*files)
+      calling_file = caller.first.split(/:\d/,2).first
+      dirname = File.dirname(calling_file)
+      files.each do |file|
+        path = File.join(dirname, file)
+        instance_eval(File.read(path), path)
+      end
+    end
+
     private
     def verify_param(param_name, err_msg)
       raise Cfer::Util::CferError, err_msg if (@parameters[param_name] && !yield(@parameters[param_name].to_s))

--- a/spec/cfer_spec.rb
+++ b/spec/cfer_spec.rb
@@ -19,6 +19,14 @@ describe Cfer do
     expect(stack[:Resources][:abc][:Type]).to eq 'Cfer::TestResource'
   end
 
+  it 'includes templates from files' do
+    stack = Cfer::stack_from_file('spec/support/includes_stack.rb')
+
+    expect(stack[:Resources]).to have_key :abc
+    expect(stack[:Resources][:abc][:Type]).to eq 'Cfer::TestResource'
+    expect(stack[:Resources][:abc][:Properties][:Tags]).to contain_exactly 'Key' => :Name, 'Value' => 'foo'
+  end
+
   it 'passes parameters and options' do
     stack = create_stack parameters: {:param => 'value'}, option: 'value' do
       parameter :param_value, default: parameters[:param]

--- a/spec/support/included_stack.rb
+++ b/spec/support/included_stack.rb
@@ -1,0 +1,3 @@
+resource :abc, "Cfer::TestResource" do
+  tag :Name, TEST_CONSTANT
+end

--- a/spec/support/includes_stack.rb
+++ b/spec/support/includes_stack.rb
@@ -1,0 +1,2 @@
+TEST_CONSTANT = 'foo'
+include_template 'included_stack.rb'


### PR DESCRIPTION
Fixes https://github.com/seanedwards/cfer/issues/1.

@seanedwards I'm not delighted by the hackiness of this, but it seems to be the simplest possible thing that works in a reasonable manner. I've tried to follow the principle of least surprise, i.e. included template files are relative paths to the base template file (as given with `converge -t` option). They are `instance_eval`ed in the order given, and in the same binding as the main template, so variables are in scope in the obvious way. Included spec can probably be improved as well.