### PR TITLE
add converge options stack_policy and stack_policy_during_update

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,10 +65,12 @@ Creates or updates a CloudFormation stack according to the specified template.
 
 The following options may be used with the `converge` command:
 
-* `--follow` (`-f`): Follows stack events on standard output as the create/update process takes place. 
+* `--follow` (`-f`): Follows stack events on standard output as the create/update process takes place.
 * `--stack-file <template.rb>`: Reads this file from the filesystem, rather than the default `<stack-name>.rb`
 * `--parameters <Key1>:<Value1> <Key2>:<Value2> ...`: Specifies input parameters, which will be available to Ruby in the `parameters` hash, or to CloudFormation by using the `Fn::ref` function
 * `--on-failure <DELETE|ROLLBACK|DO_NOTHING>`: Specifies the action to take when a stack creation fails. Has no effect if the stack already exists and is being updated.
+* `--stack-policy <filename|URL|JSON string>` (`-s`): Stack policy to apply to the stack in order to control updates; takes a local filename containing the policy, a URL to an S3 object, or a raw JSON string.
+* `--stack-policy-during-update <filename|URL|JSON string>` (`-u`): Stack policy as in `--stack-policy` option above, but applied as a temporary override to the permanent policy during stack update.
 
 #### `tail <stack-name>`
 
@@ -76,7 +78,7 @@ Prints the latest `n` stack events, and optionally follows events while a stack 
 
 The following options may be used with the `tail` command:
 
-* `--follow` (`-f`): Follows stack events on standard output as the create/update process takes place. 
+* `--follow` (`-f`): Follows stack events on standard output as the create/update process takes place.
 * `--number` (`-n`): Print the last `n` stack events.
 
 ### Template Anatomy
@@ -262,4 +264,3 @@ This project also contains a [Code of Conduct](CODE_OF_CONDUCT.md), which should
 * Branch from `develop`
 * Merge into `develop` and `master`
 * Name branch `release/<major.minor>`
-

--- a/lib/cfer/cli.rb
+++ b/lib/cfer/cli.rb
@@ -49,6 +49,14 @@ module Cfer
       aliases: :t,
       type: :string,
       desc: 'Override the stack filename (defaults to <stack-name>.rb)'
+    method_option :stack_policy,
+      aliases: :s,
+      type: :string,
+      desc: 'Set a new stack policy on create or update of the stack [file|url|json]'
+    method_option :stack_policy_during_update,
+      aliases: :u,
+      type: :string,
+      desc: 'Set a temporary overriding stack policy during an update [file|url|json]'
     template_options
     stack_options
     def converge(stack_name)
@@ -135,4 +143,3 @@ module Cfer
 
 
 end
-


### PR DESCRIPTION
This adds the following two options to `converge` command:

- `--stack-policy`
- `--stack-policy-during-update`

using, I think, the minimum necessary changes. The options can take a local filename containing JSON, a raw JSON string (validated), or a URL to an S3 object containing the JSON.

Example JSON to use would be:

```
{
  "Statement" : [
    {
      "Effect" : "Allow",
      "Action" : "Update:*",
      "Principal": "*",
      "Resource" : "*"
    }
  ]
}
```

Unfortunately, the rspec for the stack code here is a bit outside the range of my (admittedly dismal) rspec-fu, so humble apologies for not including tests. I'll continue to work on that, but would appreciate any pointers for where to start.
