### PR TITLE
feature: add stack remove

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,19 @@ The following options may be used with the `tail` command:
 * `--follow` (`-f`): Follows stack events on standard output as the create/update process takes place. 
 * `--number` (`-n`): Print the last `n` stack events.
 
+#### `remove <stack-name>`
+
+Removes or deletes an existing CloudFormation stack. 
+
+```bash
+cfer remove vpc --profile [YOUR-PROFILE] --region [YOUR-REGION]
+```
+
+This can also be done in the following way with the awscli tools, but now eliminates the need to install that package.
+```bash
+aws cloudformation delete-stack --stack-name vpc
+```
+
 ### Template Anatomy
 
 See the `examples` directory for some examples of complete templates.

--- a/lib/cfer.rb
+++ b/lib/cfer.rb
@@ -104,6 +104,13 @@ module Cfer
       puts render_json(stack, options)
     end
 
+    def remove!(stack_name, options = {})
+      config(options)
+      cfn = options[:aws_options] || {}
+      cfn_stack = Cfer::Cfn::Client.new(cfn.merge(stack_name: stack_name))
+      cfn_stack.delete_stack(stack_name)
+    end
+
     # Builds a Cfer::Core::Stack from a Ruby block
     #
     # @param options [Hash] The stack options

--- a/lib/cfer/cfn/client.rb
+++ b/lib/cfer/cfn/client.rb
@@ -19,6 +19,17 @@ module Cfer::Cfn
       end
     end
 
+
+    def delete_stack(stack_name)
+      begin
+        @cfn.delete_stack({
+  		stack_name: stack_name, # required
+	})
+      rescue Aws::CloudFormation::Errors
+        raise CferError, "Stack delete #{stack_name}"
+      end
+    end
+
     def responds_to?(method)
       @cfn.responds_to? method
     end
@@ -133,6 +144,11 @@ module Cfer::Cfn
     def to_h
       @stack.to_h
     end
+
+    def remove(stack_name, options = {})
+      delete_stack(stack_name) 
+    end
+
 
     private
 

--- a/lib/cfer/cli.rb
+++ b/lib/cfer/cli.rb
@@ -61,6 +61,12 @@ module Cfer
       Cfer.describe! stack_name, options
     end
 
+    desc 'remove <stack>', 'Remove a CloudFormation stack'
+    stack_options
+    def remove(stack_name)
+      Cfer.remove! stack_name, options
+    end
+
     desc 'tail <stack>', 'Follows stack events on standard output as they occur'
     method_option :follow,
       aliases: :f,


### PR DESCRIPTION
stack remove - a cloudformation delete-stack proposal eliminating the need to use awscli.  not really married to the name 'remove' while considering 'destroy', 'delete', or 'demolish' suitable alternatives. a handy tool while ramping up on cfer.

