### PR TITLE
allowed_values should return array and not csv

### DIFF
--- a/lib/cfer/core/stack.rb
+++ b/lib/cfer/core/stack.rb
@@ -81,9 +81,8 @@ module Cfer::Core
         param[k] =
           case k
           when :AllowedValues
-            str_list = v.join(',')
-            verify_param(name, "Parameter #{name} must be one of: #{str_list}") { |input_val| str_list.include?(input_val) }
-            str_list
+            verify_param(name, "Parameter #{name} must be one of: #{v.join(',')}") { |input_val| v.include?(input_val) }
+            v
           when :AllowedPattern
             if v.class == Regexp
               verify_param(name, "Parameter #{name} must match /#{v.source}/") { |input_val| v =~ input_val }

--- a/spec/cfer_spec.rb
+++ b/spec/cfer_spec.rb
@@ -51,7 +51,7 @@ describe Cfer do
     expect(stack[:Parameters][:test][:Type]).to eq 'String'
 
     expect(stack[:Parameters][:regex][:AllowedPattern]).to eq '[abc]+123'
-    expect(stack[:Parameters][:list][:AllowedValues]).to eq 'a,b,c'
+    expect(stack[:Parameters][:list][:AllowedValues]).to eq ['a', 'b', 'c']
   end
 
   it 'fails parameter validations' do


### PR DESCRIPTION
This is documented here by AWS:
https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/parameters-section-structure.html