### PR TITLE
chef-solo provisioner improvements

### DIFF
--- a/lib/cferext/provisioning/chef.rb
+++ b/lib/cferext/provisioning/chef.rb
@@ -4,7 +4,6 @@ module CferExt::Provisioning
 
   def install_chef(options = {})
     setup_set = [ :install_chef ]
-    run_set = [ :run_chef ]
     cfn_init_config :install_chef do
       command :install_chef, "curl https://www.opscode.com/chef/install.sh | bash -s -- -v #{options[:version] || 'latest'}"
       command :make_ohai_hints, 'mkdir -p /etc/chef/ohai/hints && touch /etc/chef/ohai/hints/ec2.json'
@@ -38,38 +37,64 @@ module CferExt::Provisioning
         file '/var/chef/Berksfile', content: options[:berksfile].strip_heredoc
         command :run_berkshelf, 'bash -l /var/chef/berkshelf.sh', cwd: '/var/chef'
       end
-      run_set.prepend :run_berkshelf
     end
 
     cfn_init_config_set :install_chef, setup_set
-    cfn_init_config_set :run_chef, run_set
+  end
 
+  def set_chef_json(json = {})
+    self[:Metadata]['CferExt::Provisioning::Chef'] = json || {}
+  end
+
+  def build_write_json_cmd(chef_solo_json_path)
+    Cfer::Core::Fn.join('', [
+      "mkdir -p #{File.dirname(chef_solo_json_path)} && cfn-get-metadata --region ",
+        Cfer::Cfn::AWS.region,
+        ' -s ', Cfer::Cfn::AWS.stack_name, ' -r ', @name,
+        " | python -c 'import sys; import json; print " \
+          "json.dumps(json.loads(sys.stdin.read()).get(" \
+          '"CferExt::Provisioning::Chef",  {}), sort_keys=True, indent=2)',
+        "' > #{chef_solo_json_path}"
+    ])
   end
 
   def chef_solo(options = {})
     raise "Chef already configured on this resource" if @chef
     @chef = true
 
-    chef_config = options[:node] || raise('`node` required when setting up chef')
+    chef_solo_config_path = options[:config_path] || '/etc/chef/solo.rb'
+    chef_solo_json_path = options[:json_path] || '/etc/chef/config.json'
 
-    install_chef(options)
+    chef_cookbook_path = options[:cookbook_path] || '/var/chef/cookbooks'
+    chef_log_path = options[:log_path] || '/var/log/chef-client.log'
+
+    install_chef(options) unless options[:no_install]
+
+    set_chef_json(options[:json])
+    write_json_cmd = build_write_json_cmd(chef_solo_json_path)
+
+    cfn_init_config :write_chef_json do
+      command :write_chef_json, write_json_cmd
+    end
 
     cfn_init_config :run_chef do
-      file "/etc/chef/solo.rb", content: options[:solo_rb] || Cfer::Core::Fn::join("\n", [
-          "cookbook_path '/var/chef/cookbooks'",
-          "log_location '/var/log/chef-client.log'"
+      file chef_solo_config_path, content: options[:solo_rb] || Cfer::Core::Fn.join("\n", [
+          "cookbook_path '#{chef_cookbook_path}'",
+          "log_location '#{chef_log_path}'",
+          ""
         ]),
         owner: 'root',
         group: 'root'
 
-      file "/etc/chef/config.json", content: chef_config.to_json,
-        owner: 'root',
-        group: 'root'
-
-      chef_cmd = 'chef-solo -c /etc/chef/solo.rb -j /etc/chef/config.json'
+      chef_cmd = "chef-solo -c '#{chef_solo_config_path}' -j '#{chef_solo_json_path}'"
       chef_cmd << " -o '#{options[:run_list].join(',')}'" if options[:run_list]
+
       command :run_chef, chef_cmd
     end
+
+    run_set = [ :write_chef_json, :run_chef ]
+    run_set.prepend :run_berkshelf if options[:berkshelf]
+    cfn_init_config_set :run_chef, run_set
   end
 end
 


### PR DESCRIPTION
(this is based off `feature/yaml-parameter-input` branch)

- replaced the `node` weirdness with a `json` hash that gets
  loaded into CF metadata (so Fn::Ref and Fn::GetAtt work)
- lots of new options for chef-solo
- made installing aws-cfn-bootstrap dependent on it not already
  existing; speeds up instance launch by about 15 seconds
- fixed cfn-hup to fire on _any_ Metadata change so it re-runs
  on changes to the chef json (no cron chef-clients)