### PR TITLE
Make templates easier to read when previewing changesets.

### DIFF
--- a/lib/cfer/core/stack.rb
+++ b/lib/cfer/core/stack.rb
@@ -155,7 +155,11 @@ module Cfer::Core
     # Renders the stack into a CloudFormation template.
     # @return [String] The final template
     def to_cfn
-      to_h.to_json
+      if @options[:pretty_print]
+        JSON.pretty_generate(to_h)
+      else
+        to_h.to_json
+      end
     end
 
     # Gets the Cfn client, if one exists, or throws an error if one does not


### PR DESCRIPTION
Without this change, the preview just shows all json on one line.

If there should be specs for this, I couldn't figure out where they should live.

If it isn't safe to re-use the pretty-print option for this purpose, I can add a new option, or just pass an optional arg to #to_cfn when building a changeset so this doesn't affect other operations that make use of #to_cfn.