### PR TITLE
Default Fn::get_azs argument to empty string, i.e. current region

### DIFF
--- a/lib/cfer/core/functions.rb
+++ b/lib/cfer/core/functions.rb
@@ -44,7 +44,7 @@ module Cfer::Core::Functions
     {"Fn::Not" => [cond]}
   end
 
-  def get_azs(region)
+  def get_azs(region = '')
     {"Fn::GetAZs" => region}
   end
 


### PR DESCRIPTION
Fixes #51 

Empty implies current region, hence these are all now equivalent:

```
Fn::get_azs
Fn::get_azs('')
Fn::get_azs(Fn::ref('AWS::Region'))
```
