### PR TITLE
Add Fn::split

### DIFF
--- a/lib/cfer/core/functions.rb
+++ b/lib/cfer/core/functions.rb
@@ -48,6 +48,10 @@ module Cfer::Core::Functions
     {"Fn::GetAZs" => region}
   end
 
+  def split(*args)
+    {"Fn::Split" => [ *args ].flatten }
+  end
+
   def sub(str, vals = {})
     {"Fn::Sub" => [str, vals]}
   end


### PR DESCRIPTION
Fixes #57 

Usage:

```
Fn::split(',', "string,to,split")
```
