### PR TITLE
Fix type checking on number of stack elements argument.

### DIFF
--- a/lib/cfer/cli.rb
+++ b/lib/cfer/cli.rb
@@ -91,7 +91,7 @@ module Cfer
       summary 'Follows stack events on standard output as they occur'
 
       flag :f, 'follow', 'Follow stack events on standard output while the changes are made.'
-      optional :n, 'number', 'Prints the last (n) stack events.', type: :number
+      option :n, 'number', 'Prints the last (n) stack events.', argument: :optional, transform: method(:Integer)
 
       run do |options, args, cmd|
         Cfer::Cli.fixup_options(options)


### PR DESCRIPTION
cri 2.15.1 checks for arguments that do not exist, and 'type' was one of them. This option has been changed to use the new format (optional is deprecated), and it tries to cast the argument to Integer.