### PR TITLE
Ensure Aws::S3 constant is loaded to allow template upload.

### DIFF
--- a/lib/cfer.rb
+++ b/lib/cfer.rb
@@ -1,5 +1,6 @@
 require 'active_support/all'
 require 'aws-sdk-cloudformation'
+require 'aws-sdk-s3'
 require 'logger'
 require 'json'
 require 'preconditions'


### PR DESCRIPTION
Without this, this code fails with `NameError: uninitialized constant Aws::S3`:
https://github.com/seanedwards/cfer/blob/master/lib/cfer/cfn/client.rb#L285-L287
```ruby
          uri = URI(options[:s3_path])
          template = Aws::S3::Object.new bucket_name: uri.host, key: uri.path.reverse.chomp('/').reverse
          template.put body: cfn_hash
```
